### PR TITLE
Fix and complete Cloud Solutions peripheral types

### DIFF
--- a/projects/typed-peripheral-cloudsolutions/build.gradle.kts
+++ b/projects/typed-peripheral-cloudsolutions/build.gradle.kts
@@ -35,6 +35,8 @@ val compileTypeScript by tasks.registering(NpmTask::class) {
         file("lualib_bundle.lua"),
         file("statsdBridge.d.ts"),
         file("statsdBridge.lua"),
+        file("tsdbStorage.d.ts"),
+        file("tsdbStorage.lua"),
     )
 }
 

--- a/projects/typed-peripheral-cloudsolutions/crafkaBroker.d.ts
+++ b/projects/typed-peripheral-cloudsolutions/crafkaBroker.d.ts
@@ -1,30 +1,37 @@
 import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
 import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+type CrafkaResult = LuaMultiReturn<[
+    boolean | null,
+    number | string | null
+]>;
+type CrafkaSubscription = {
+    cursor: number;
+    fragile: boolean;
+    autoCursor: boolean;
+};
 /** @noSelf **/
 export interface CrafkaBroker extends ConfigurationAPI<object> {
-    createTopic(name: string, messageLimit?: number): Result;
+    createTopic(name: string, messageLimit?: number): CrafkaResult;
     listTopics(): string[];
     deleteTopic(name: string): Result;
     publish(topic: string, message: string): Result;
-    fetchMessages(topic: string, cursor: number): [number, string][];
+    fetchMessages(topic: string, cursor: number): LuaTable<number, string>;
     describeTopic(topic: string): {
         messageLimit: number;
         firstMessage: number;
         lastMessage: number;
     };
-    subscribe(topic: string, options: {
+    subscribe(topic: string, options?: {
         fragile?: boolean;
         autoCursor?: boolean;
-        consumerGroup?: string;
         cursor?: number;
-    }): any;
-    unsubscribe(topic: string): any;
-    getSubscription(topic: string): {
-        cursor: number;
-        fragile: boolean;
-        autoCursor: boolean;
-        consumerGroup?: string;
-    };
-    setCursor(topic: string, cursor: number): any;
+    }): CrafkaResult;
+    unsubscribe(topic: string): Result;
+    getSubscription(topic: string): LuaMultiReturn<[
+        CrafkaSubscription | null,
+        string | null
+    ]>;
+    setCursor(topic: string, cursor: number): Result;
 }
 export declare const crafkaBrokerPeripheralProvider: IPeripheralProvider<CrafkaBroker>;
+export {};

--- a/projects/typed-peripheral-cloudsolutions/crafkaBroker.ts
+++ b/projects/typed-peripheral-cloudsolutions/crafkaBroker.ts
@@ -1,13 +1,24 @@
 import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
 import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
 
+type CrafkaResult = LuaMultiReturn<[
+    boolean | null,
+    number | string | null
+]>;
+
+type CrafkaSubscription = {
+    cursor: number;
+    fragile: boolean;
+    autoCursor: boolean;
+};
+
 /** @noSelf **/
 export interface CrafkaBroker extends ConfigurationAPI<object> {
-    createTopic(name: string, messageLimit?: number): Result;
+    createTopic(name: string, messageLimit?: number): CrafkaResult;
     listTopics(): string[];
     deleteTopic(name: string): Result;
     publish(topic: string, message: string): Result;
-    fetchMessages(topic: string, cursor: number): [number, string][];
+    fetchMessages(topic: string, cursor: number): LuaTable<number, string>;
     describeTopic(topic: string): {
         messageLimit: number;
         firstMessage: number;
@@ -15,21 +26,18 @@ export interface CrafkaBroker extends ConfigurationAPI<object> {
     };
     subscribe(
         topic: string,
-        options: {
+        options?: {
             fragile?: boolean;
             autoCursor?: boolean;
-            consumerGroup?: string;
             cursor?: number;
         }
-    );
-    unsubscribe(topic: string);
-    getSubscription(topic: string): {
-        cursor: number;
-        fragile: boolean;
-        autoCursor: boolean;
-        consumerGroup?: string;
-    };
-    setCursor(topic: string, cursor: number);
+    ): CrafkaResult;
+    unsubscribe(topic: string): Result;
+    getSubscription(topic: string): LuaMultiReturn<[
+        CrafkaSubscription | null,
+        string | null
+    ]>;
+    setCursor(topic: string, cursor: number): Result;
 }
 
 export const crafkaBrokerPeripheralProvider =

--- a/projects/typed-peripheral-cloudsolutions/kvStorage.d.ts
+++ b/projects/typed-peripheral-cloudsolutions/kvStorage.d.ts
@@ -2,20 +2,20 @@ import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
 import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
 /** @noSelf **/
 export interface KVStorage extends ConfigurationAPI<object> {
-    delete(key: string): void;
-    put(key: string, value: string, expire?: number | null): void;
+    delete(key: string): Result;
+    put(key: string, value: string, expire?: number | null): Result;
     get(key: string): string | null;
     mput(values: {
         [key: string]: string;
-    }): any;
+    }): LuaMultiReturn<[number | false, string | null]>;
     mget(values: string[]): LuaTable<string, string>;
     list(glob?: string): string[];
     get_ex(key: string): number | null;
-    put_ex(key: string, expire?: number | null): void;
+    put_ex(key: string, expire?: number | null): Result;
     incr(key: string, value?: number): number;
     decr(key: string, value?: number): number;
-    subscribe(type: "changed" | "deleted", pattern: string): any;
-    unsubscribe(type: "changed" | "deleted", pattern: string): any;
+    subscribe(type: "changed" | "deleted", pattern: string): void;
+    unsubscribe(type: "changed" | "deleted", pattern: string): void;
     getSubscriptions(type: "changed" | "deleted"): string[];
 }
 export declare const kvStoragePeripheralProvider: IPeripheralProvider<KVStorage>;

--- a/projects/typed-peripheral-cloudsolutions/kvStorage.ts
+++ b/projects/typed-peripheral-cloudsolutions/kvStorage.ts
@@ -3,18 +3,18 @@ import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
 
 /** @noSelf **/
 export interface KVStorage extends ConfigurationAPI<object> {
-    delete(key: string): void;
-    put(key: string, value: string, expire?: number | null): void;
+    delete(key: string): Result;
+    put(key: string, value: string, expire?: number | null): Result;
     get(key: string): string | null;
-    mput(values: { [key: string]: string });
+    mput(values: { [key: string]: string }): LuaMultiReturn<[number | false, string | null]>;
     mget(values: string[]): LuaTable<string, string>;
     list(glob?: string): string[];
     get_ex(key: string): number | null;
-    put_ex(key: string, expire?: number | null): void;
+    put_ex(key: string, expire?: number | null): Result;
     incr(key: string, value?: number): number;
     decr(key: string, value?: number): number;
-    subscribe(type: "changed" | "deleted", pattern: string);
-    unsubscribe(type: "changed" | "deleted", pattern: string);
+    subscribe(type: "changed" | "deleted", pattern: string): void;
+    unsubscribe(type: "changed" | "deleted", pattern: string): void;
     getSubscriptions(type: "changed" | "deleted"): string[];
 }
 

--- a/projects/typed-peripheral-cloudsolutions/statsdBridge.d.ts
+++ b/projects/typed-peripheral-cloudsolutions/statsdBridge.d.ts
@@ -2,19 +2,19 @@ import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
 import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
 /** @noSelf **/
 export interface StatsDBridge extends ConfigurationAPI<object> {
-    count(aspect: String, delta: number): any;
-    delta(aspect: String, delta: number): any;
-    gauge(aspect: String, value: number): any;
-    set(aspect: String, eventName: String): any;
-    time(aspect: String, timeInMs: number): any;
+    count(aspect: string, delta: number): void;
+    delta(aspect: string, delta: number): void;
+    gauge(aspect: string, value: number): void;
+    set(aspect: string, eventName: string): void;
+    time(aspect: string, timeInMs: number): void;
 }
 /** @noSelf **/
 export declare class DummyStatsDBridge implements StatsDBridge {
     getConfiguration(): LuaTable;
-    count(aspect: String, delta: number): void;
-    delta(aspect: String, delta: number): void;
-    gauge(aspect: String, value: number): void;
-    set(aspect: String, eventName: String): void;
-    time(aspect: String, timeInMs: number): void;
+    count(aspect: string, delta: number): void;
+    delta(aspect: string, delta: number): void;
+    gauge(aspect: string, value: number): void;
+    set(aspect: string, eventName: string): void;
+    time(aspect: string, timeInMs: number): void;
 }
 export declare const statsDBridgeProvider: IPeripheralProvider<StatsDBridge>;

--- a/projects/typed-peripheral-cloudsolutions/statsdBridge.ts
+++ b/projects/typed-peripheral-cloudsolutions/statsdBridge.ts
@@ -4,11 +4,11 @@ import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
 
 /** @noSelf **/
 export interface StatsDBridge extends ConfigurationAPI<object> {
-    count(aspect: String, delta: number);
-    delta(aspect: String, delta: number);
-    gauge(aspect: String, value: number);
-    set(aspect: String, eventName: String);
-    time(aspect: String, timeInMs: number);
+    count(aspect: string, delta: number): void;
+    delta(aspect: string, delta: number): void;
+    gauge(aspect: string, value: number): void;
+    set(aspect: string, eventName: string): void;
+    time(aspect: string, timeInMs: number): void;
 }
 
 /** @noSelf **/
@@ -16,11 +16,11 @@ export class DummyStatsDBridge implements StatsDBridge {
     getConfiguration(): LuaTable {
         return new LuaTable();
     }
-    count(aspect: String, delta: number) {}
-    delta(aspect: String, delta: number) {}
-    gauge(aspect: String, value: number) {}
-    set(aspect: String, eventName: String) {}
-    time(aspect: String, timeInMs: number) {}
+    count(aspect: string, delta: number) {}
+    delta(aspect: string, delta: number) {}
+    gauge(aspect: string, value: number) {}
+    set(aspect: string, eventName: string) {}
+    time(aspect: string, timeInMs: number) {}
 }
 
 export const statsDBridgeProvider = new IPeripheralProvider<StatsDBridge>(

--- a/projects/typed-peripheral-cloudsolutions/tsdbStorage.d.ts
+++ b/projects/typed-peripheral-cloudsolutions/tsdbStorage.d.ts
@@ -1,0 +1,11 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface TSDBStorage extends ConfigurationAPI<object> {
+    registerTimeseries(name: string, tags: LuaTable<string, string>, retention?: number): string;
+    queryTimeseries(namePattern: string, tagsQuery: LuaTable<string, string>, fromTimestamp: number, toTimestamp: number): LuaTable<string, LuaTable<number, number>>;
+    getTimeseries(): LuaTable<string, unknown>[];
+    postMeasurement(id: string, value: number): void;
+    postMeasurement(values: LuaTable<string, number>): void;
+}
+export declare const tsdbStoragePeripheralProvider: IPeripheralProvider<TSDBStorage>;

--- a/projects/typed-peripheral-cloudsolutions/tsdbStorage.ts
+++ b/projects/typed-peripheral-cloudsolutions/tsdbStorage.ts
@@ -1,0 +1,23 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface TSDBStorage extends ConfigurationAPI<object> {
+    registerTimeseries(
+        name: string,
+        tags: LuaTable<string, string>,
+        retention?: number
+    ): string;
+    queryTimeseries(
+        namePattern: string,
+        tagsQuery: LuaTable<string, string>,
+        fromTimestamp: number,
+        toTimestamp: number
+    ): LuaTable<string, LuaTable<number, number>>;
+    getTimeseries(): LuaTable<string, unknown>[];
+    postMeasurement(id: string, value: number): void;
+    postMeasurement(values: LuaTable<string, number>): void;
+}
+
+export const tsdbStoragePeripheralProvider =
+    new IPeripheralProvider<TSDBStorage>("tsdb_storage", () => null);


### PR DESCRIPTION
## Summary
- add typed-peripheral declarations and provider for `tsdb_storage`
- align Crafka result, subscription, and message table types with the Kotlin API
- align KV Storage and StatsD method return and parameter types with the Kotlin API
- register TSDB generated outputs in the Gradle build

No integration-owned peripherals are registered in the current source tree.

## Verification
- `npm run build`
- `timeout --foreground 600s ./gradlew :typed-peripheral-cloudsolutions:assemble --no-daemon`